### PR TITLE
- Run on Flutter Web

### DIFF
--- a/lib/src/widgets/cool_swiper_card.dart
+++ b/lib/src/widgets/cool_swiper_card.dart
@@ -98,18 +98,24 @@ class _CoolSwiperCardState extends State<CoolSwiperCard>
 
       animationController.forward().then((value) {
         widget.onVerticalDragEnd();
-        setState(() {
-          dragStartAngle = 0;
-        });
+        // if (mounted)
+        {
+          setState(() {
+            dragStartAngle = 0;
+          });
+        }
       });
     } else {
-      setState(() {
-        // Set a non-zero drag rotation to allow the card to reset to original
-        // position smoothly rather than snapping back into place
-        dragDuration = const Duration(milliseconds: 200);
-        yDragOffset = 0;
-        dragStartAngle = 0;
-      });
+      // if (mounted)
+      {
+        setState(() {
+          // Set a non-zero drag rotation to allow the card to reset to original
+          // position smoothly rather than snapping back into place
+          dragDuration = const Duration(milliseconds: 200);
+          yDragOffset = 0;
+          dragStartAngle = 0;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
- Fixed error by adding condition is `mounted` for setState

Got the error as follows and fixed:

```
Error: setState() called after dispose(): _CoolSwiperCardState#b8694(lifecycle state: defunct, not mounted, ticker inactive)
This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
    at Object.throw_ [as throw] (http://localhost:57678/dart_sdk.js:5080:11)
    at http://localhost:57678/packages/flutter/src/widgets/title.dart.lib.js:11577:23
    at cool_swiper_card._CoolSwiperCardState.new.setState (http://localhost:57678/packages/flutter/src/widgets/title.dart.lib.js:11583:28)
    at http://localhost:57678/packages/flutter_card_swiper/src/widgets/cool_swiper_card.dart.lib.js:348:18
    at _RootZone.runUnary (http://localhost:57678/dart_sdk.js:40511:59)
    at _FutureListener.then.handleValue (http://localhost:57678/dart_sdk.js:35438:29)
    at handleValueCallback (http://localhost:57678/dart_sdk.js:35999:49)
    at _Future._propagateToListeners (http://localhost:57678/dart_sdk.js:36037:17)
    at [_completeWithValue] (http://localhost:57678/dart_sdk.js:35872:23)
    at async._AsyncCallbackEntry.new.callback (http://localhost:57678/dart_sdk.js:35906:35)
    at Object._microtaskLoop (http://localhost:57678/dart_sdk.js:40778:13)
    at _startMicrotaskLoop (http://localhost:57678/dart_sdk.js:40784:13)
    at http://localhost:57678/dart_sdk.js:36261:9
```